### PR TITLE
Add a force update option

### DIFF
--- a/lib/DirectEditing.js
+++ b/lib/DirectEditing.js
@@ -97,7 +97,7 @@ DirectEditing.prototype.complete = function() {
     newText !== previousText ||
     newBounds.height !== previousBounds.height ||
     newBounds.width !== previousBounds.width ||
-    active.context.forceUpdate
+    active.context.options.forceUpdate
   ) {
     containerBounds = this._textbox.container.getBoundingClientRect();
 

--- a/lib/DirectEditing.js
+++ b/lib/DirectEditing.js
@@ -96,7 +96,8 @@ DirectEditing.prototype.complete = function() {
   if (
     newText !== previousText ||
     newBounds.height !== previousBounds.height ||
-    newBounds.width !== previousBounds.width
+    newBounds.width !== previousBounds.width ||
+    active.context.forceUpdate
   ) {
     containerBounds = this._textbox.container.getBoundingClientRect();
 

--- a/test/DirectEditingSpec.js
+++ b/test/DirectEditingSpec.js
@@ -459,6 +459,33 @@ describe('diagram-js-direct-editing', function() {
         }
       ));
 
+      it('should update with forceUpdate', inject(
+        function(canvas, directEditing, directEditingProvider) {
+
+          // given
+          sinon.spy(directEditingProvider, 'update');
+
+          directEditingProvider.setOptions({ forceUpdate: true });
+
+          var shapeWithLabel = {
+            id: 's1',
+            x: 20, y: 10, width: 60, height: 50,
+            label: 'FOO',
+            labelBounds: { x: 100, y: 200, width: 300, height: 20 }
+          };
+
+          canvas.addShape(shapeWithLabel);
+
+          // when
+          directEditing.activate(shapeWithLabel);
+
+          directEditing.complete();
+
+          // then
+          expect(directEditingProvider.update).to.have.been.called;
+        }
+      ));
+
     });
 
 


### PR DESCRIPTION
Closes #15 

## Changes
- Force a call of `directEditingProvider.update` when `options.forceUpdate` is enabled, even if nothing changed