### PR TITLE
deps: support diagram-js@8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js-direct-editing](https://github.com/bpmn-io/di
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.6.4
+
+* `CHORE`: support diagram-js@8
+
 ## 1.6.3
 
 * `FIX`: preserve Windows newline characters ([#19](https://github.com/bpmn-io/diagram-js-direct-editing/pull/19))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ## 1.6.4
 
-* `CHORE`: support diagram-js@8
+* `DEPS`: support diagram-js@8
 
 ## 1.6.3
 
@@ -16,19 +16,19 @@ ___Note:__ Yet to be released changes appear here._
 
 ## 1.6.2
 
-* `CHORE`: support diagram-js@7
+* `DEPS`: support diagram-js@7
 
 ## 1.6.1
 
-* `CHORE`: support diagram-js@6
+* `DEPS`: support diagram-js@6
 
 ## 1.6.0
 
-* `CHORE`: support diagram-js@5
+* `DEPS`: support diagram-js@5
 
 ## 1.5.0
 
-* `CHORE`: support diagram-js@4
+* `DEPS`: support diagram-js@4
 
 ## 1.4.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,9 +1692,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.0.0.tgz",
-      "integrity": "sha512-Tz4yAurGSnTC2rSZjP2oPOkJjBjBFF7oQ9MVNYJU88j7jxAs38LjyzDZzEhLz0VZXHpMZhW2gKeVLMD1YtFNjg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.0.2.tgz",
+      "integrity": "sha512-W7qAIqlOGOFeboG+zqImnMyWlPyuQmxrtZx7lSMB5NAMP4P5IqEwBCZttCTZVJt7R6Fbfbdic6Pn7X4hbzaidQ==",
       "dev": true,
       "requires": {
         "css.escape": "^1.5.1",
@@ -1704,7 +1704,7 @@
         "min-dash": "^3.5.2",
         "min-dom": "^3.1.3",
         "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.0",
+        "path-intersection": "^2.2.1",
         "tiny-svg": "^2.2.2"
       },
       "dependencies": {
@@ -5192,9 +5192,9 @@
       "dev": true
     },
     "path-intersection": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.0.tgz",
-      "integrity": "sha512-1qchRuLKhRt3qYePf9CU/74fLrBo9OTiKYNn5fxfuHJW6kTThEk04ql7w8JwOgZjNANAGp1052tWGpwZ7ItNRA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
       "dev": true
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^2.3.0",
-    "diagram-js": "^7.0.0",
+    "diagram-js": "^8.0.0",
     "eslint": "^4.12.0",
     "eslint-plugin-bpmn-io": "^0.5.2",
     "karma": "^4.0.1",
@@ -45,7 +45,7 @@
     "min-dom": "^3.1.3"
   },
   "peerDependencies": {
-    "diagram-js": "^0.x || ^1.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x || ^7.x"
+    "diagram-js": "^0.x || ^1.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x || ^7.x || ^8.x"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Support diagram-js@8. If released, gets rid of the incompatibility warning when installing the library along with the new diagram-js version.