### PR TITLE
Restore main export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [diagram-js-direct-editing](https://github.com/bpmn-io/di
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.1.2
+
+_This reverts `v2.1.1`._
+
+* `FIX`: restore `main` package export
+
 ## 2.1.1
 
 * `FIX`: drop `main` package export

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "engines": {
     "node": "*"
   },
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "author": "bpmn.io",
   "license": "MIT",


### PR DESCRIPTION
I'm not sure in which magic world `vitest` is even able to import this library as a commonjs module (it does not pick up the `module` field), and then goes ahead and treat it like an ES module. 

But whatever. Let's restore the (wrong) entry point until we decide to bundle this library or turn it into a proper ES module with `package.json#exports` declaration.

Closes #27 