### PR TITLE
feat: remove background for non-resizable textboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to [diagram-js-direct-editing](https://github.com/bpmn-io/di
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: remove background for non-resizable textboxes ([#23](https://github.com/bpmn-io/diagram-js-direct-editing/issues/23))
+
+### Breaking Changes
+
+* By default, no background is shown when editing a static sized element. To restore old behavior, add a style config when activating direct editing:
+  ```
+  const MyProvider = { 
+    activate: (element) => {
+      return {
+        style: {
+          backgroundColor: '#ffffff',
+          border: '1px solid #ccc'
+        }
+        // ...
+      }
+    }
+  }
+  ```
+
 ## 2.1.2
 
 _This reverts `v2.1.1`._

--- a/lib/TextBox.js
+++ b/lib/TextBox.js
@@ -120,10 +120,8 @@ TextBox.prototype.create = function(bounds, style, value, options) {
     minHeight: bounds.minHeight + 'px',
     left: bounds.x + 'px',
     top: bounds.y + 'px',
-    backgroundColor: '#ffffff',
     position: 'absolute',
     overflow: 'visible',
-    border: '1px solid #ccc',
     boxSizing: 'border-box',
     wordWrap: 'normal',
     textAlign: 'center',
@@ -168,6 +166,11 @@ TextBox.prototype.create = function(bounds, style, value, options) {
   }
 
   if (options.resizable) {
+    assign(parent.style, {
+      backgroundColor: '#ffffff',
+      border: '1px solid #ccc'
+    });
+
     this.resizable(style);
   }
 

--- a/test/DirectEditingSpec.js
+++ b/test/DirectEditingSpec.js
@@ -551,8 +551,10 @@ describe('diagram-js-direct-editing', function() {
 
         // then
         var resizeHandle = directEditing._textbox.parent.getElementsByClassName('djs-direct-editing-resize-handle')[0];
+        var parent = directEditing._textbox.parent;
 
         expect(resizeHandle).to.exist;
+        expect(parent.getAttribute('style').indexOf('background-color:')).not.to.eql(-1);
       }));
 
 
@@ -571,8 +573,10 @@ describe('diagram-js-direct-editing', function() {
 
         // then
         var resizeHandle = directEditing._textbox.parent.getElementsByClassName('djs-direct-editing-resize-handle')[0];
+        var parent = directEditing._textbox.parent;
 
         expect(resizeHandle).not.to.exist;
+        expect(parent.getAttribute('style').indexOf('background-color:')).to.eql(-1);
       }));
 
 


### PR DESCRIPTION
This PR removes the background for non-resizable textboxes. This ensures we do not overlap with other UI elements, such as task icons or the new context pad entries.

![image](https://github.com/bpmn-io/diagram-js-direct-editing/assets/21984219/60e2e9d4-0674-43e3-8d49-9da640096110)

Try it out with
```
npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js-direct-editing#23-remove-background
```

closes #23
related to https://github.com/camunda/web-modeler/issues/8477

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
