### PR TITLE
revert: remove background for non-resizable textboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [diagram-js-direct-editing](https://github.com/bpmn-io/di
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.0.1
+
+_This reverts `v3.0.0`._
+
+* `FEAT`: restore background for all textboxes. You can remove the background with custom styles or a style config in direct editing provider.
+
 ## 3.0.0
 
 * `FEAT`: remove background for non-resizable textboxes ([#23](https://github.com/bpmn-io/diagram-js-direct-editing/issues/23))

--- a/lib/TextBox.js
+++ b/lib/TextBox.js
@@ -120,8 +120,10 @@ TextBox.prototype.create = function(bounds, style, value, options) {
     minHeight: bounds.minHeight + 'px',
     left: bounds.x + 'px',
     top: bounds.y + 'px',
+    backgroundColor: '#ffffff',
     position: 'absolute',
     overflow: 'visible',
+    border: '1px solid #ccc',
     boxSizing: 'border-box',
     wordWrap: 'normal',
     textAlign: 'center',
@@ -166,11 +168,6 @@ TextBox.prototype.create = function(bounds, style, value, options) {
   }
 
   if (options.resizable) {
-    assign(parent.style, {
-      backgroundColor: '#ffffff',
-      border: '1px solid #ccc'
-    });
-
     this.resizable(style);
   }
 

--- a/test/DirectEditingSpec.js
+++ b/test/DirectEditingSpec.js
@@ -551,10 +551,8 @@ describe('diagram-js-direct-editing', function() {
 
         // then
         var resizeHandle = directEditing._textbox.parent.getElementsByClassName('djs-direct-editing-resize-handle')[0];
-        var parent = directEditing._textbox.parent;
 
         expect(resizeHandle).to.exist;
-        expect(parent.getAttribute('style').indexOf('background-color:')).not.to.eql(-1);
       }));
 
 
@@ -573,10 +571,8 @@ describe('diagram-js-direct-editing', function() {
 
         // then
         var resizeHandle = directEditing._textbox.parent.getElementsByClassName('djs-direct-editing-resize-handle')[0];
-        var parent = directEditing._textbox.parent;
 
         expect(resizeHandle).not.to.exist;
-        expect(parent.getAttribute('style').indexOf('background-color:')).to.eql(-1);
       }));
 
 


### PR DESCRIPTION
As discusses in https://github.com/bpmn-io/diagram-js-direct-editing/pull/39#issuecomment-2071929193 , removing background should be a application concern.

This Re-enables the previous behavior of adding a background for all options.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
