### PR TITLE
fix: complete direct editing on focusout

### DIFF
--- a/lib/DirectEditing.js
+++ b/lib/DirectEditing.js
@@ -22,7 +22,8 @@ export default function DirectEditing(eventBus, canvas) {
   this._textbox = new TextBox({
     container: canvas.getContainer(),
     keyHandler: bind(this._handleKey, this),
-    resizeHandler: bind(this._handleResize, this)
+    resizeHandler: bind(this._handleResize, this),
+    focusoutHandler: bind(this._handleFocusout, this)
   });
 }
 
@@ -149,6 +150,34 @@ DirectEditing.prototype._handleKey = function(e) {
 
 DirectEditing.prototype._handleResize = function(event) {
   this._fire('resize', event);
+};
+
+
+DirectEditing.prototype._handleFocusout = function(event) {
+
+  // ignore if focus moves to a child element of the textbox
+  if (event.relatedTarget && this._textbox.parent.contains(event.relatedTarget)) {
+    return;
+  }
+
+  // ignore if the textbox content is already detached from the DOM
+  // to prevent NotFoundError during cleanup (uses contains() for broader browser support)
+  if (!event.target || !document.documentElement.contains(event.target)) {
+    return;
+  }
+
+  // prevent re-entrant calls
+  if (this._completing) {
+    return;
+  }
+
+  this._completing = true;
+
+  try {
+    this.complete();
+  } finally {
+    this._completing = false;
+  }
 };
 
 

--- a/lib/TextBox.js
+++ b/lib/TextBox.js
@@ -44,6 +44,7 @@ function toArray(nodeList) {
  * @param {DOMElement} options.container The DOM element to append the contentContainer to
  * @param {Function} options.keyHandler Handler for key events
  * @param {Function} options.resizeHandler Handler for resize events
+ * @param {Function} [options.focusoutHandler] Handler for focusout events
  */
 export default function TextBox(options) {
   this.container = options.container;
@@ -58,6 +59,7 @@ export default function TextBox(options) {
 
   this.keyHandler = options.keyHandler || function() {};
   this.resizeHandler = options.resizeHandler || function() {};
+  this.focusoutHandler = options.focusoutHandler || function() {};
 
   this.autoResize = bind(this.autoResize, this);
   this.handlePaste = bind(this.handlePaste, this);
@@ -162,6 +164,7 @@ TextBox.prototype.create = function(bounds, style, value, options) {
   domEvent.bind(content, 'keydown', this.keyHandler);
   domEvent.bind(content, 'mousedown', stopPropagation);
   domEvent.bind(content, 'paste', self.handlePaste);
+  domEvent.bind(content, 'focusout', this.focusoutHandler);
 
   if (options.autoResize) {
     domEvent.bind(content, 'input', this.autoResize);
@@ -414,6 +417,7 @@ TextBox.prototype.destroy = function() {
   domEvent.unbind(content, 'mousedown', stopPropagation);
   domEvent.unbind(content, 'input', this.autoResize);
   domEvent.unbind(content, 'paste', this.handlePaste);
+  domEvent.unbind(content, 'focusout', this.focusoutHandler);
 
   if (resizeHandle) {
     resizeHandle.removeAttribute('style');

--- a/test/DirectEditingSpec.js
+++ b/test/DirectEditingSpec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spy, restore } from 'sinon';
+import { spy, stub, restore } from 'sinon';
 
 import {
   bootstrapDiagram,
@@ -705,6 +705,136 @@ describe('diagram-js-direct-editing', function() {
 
         // then
         expect(directEditing._textbox.content.innerHTML).to.eql('FOOFoo<div><br></div><div>Bar</div>');
+      }));
+
+    });
+
+
+    describe('complete on focus loss (focusout)', function() {
+
+      var mockProvider;
+
+      beforeEach(inject(function(directEditing) {
+
+        // register a minimal mock provider
+        mockProvider = {
+          activate: function(element) {
+            return {
+              bounds: { x: 10, y: 10, width: 100, height: 40 },
+              style: {},
+              text: 'label',
+              options: {}
+            };
+          },
+          update: function() {}
+        };
+
+        directEditing.registerProvider(mockProvider);
+        directEditing.activate({});
+      }));
+
+      afterEach(inject(function(directEditing) {
+        if (directEditing.isActive()) {
+          directEditing.cancel();
+        }
+      }));
+
+
+      it('should complete when focus moves to an external element', inject(function(directEditing) {
+
+        // given
+        var externalElement = document.createElement('div');
+        document.body.appendChild(externalElement);
+
+        var content = directEditing._textbox.content;
+
+        // when - dispatch a focusout with an external relatedTarget
+        var focusEvent = document.createEvent('Event');
+        focusEvent.initEvent('focusout', true, true);
+        focusEvent.relatedTarget = externalElement;
+
+        content.dispatchEvent(focusEvent);
+
+        // then
+        expect(directEditing.isActive()).to.eql(false);
+
+        // cleanup
+        document.body.removeChild(externalElement);
+      }));
+
+
+      it('should complete when the browser window loses focus (relatedTarget is null)', inject(function(directEditing) {
+
+        // given
+        var content = directEditing._textbox.content;
+
+        // when - dispatch a focusout with no relatedTarget (window blur)
+        var focusEvent = document.createEvent('Event');
+        focusEvent.initEvent('focusout', true, true);
+        focusEvent.relatedTarget = null;
+
+        content.dispatchEvent(focusEvent);
+
+        // then
+        expect(directEditing.isActive()).to.eql(false);
+      }));
+
+
+      it('should NOT complete when the textbox content is already detached', inject(function(directEditing) {
+
+        // given
+        var completeSpy = spy(directEditing, 'complete');
+
+        // Create a detached element (never appended to the document),
+        // so document.documentElement.contains() returns false for it.
+        // We call the handler directly to avoid triggering a real browser
+        // focusout when physically removing a focused node from the DOM.
+        var detachedEl = document.createElement('div');
+
+        // when - invoke the handler with a mock event whose target is detached
+        directEditing._handleFocusout({ target: detachedEl, relatedTarget: null });
+
+        // then - complete should not have been called
+        expect(completeSpy).to.not.have.been.called;
+
+        // manually close since we prevented completion
+        directEditing.cancel();
+      }));
+
+
+      it('should NOT call complete() twice when focusout fires re-entrantly', inject(function(directEditing) {
+
+        // given
+        var content = directEditing._textbox.content;
+        var callCount = 0;
+        var originalComplete = directEditing.complete.bind(directEditing);
+
+        // stub complete() to fire a second synchronous focusout before doing real work;
+        // sinon.stub auto-restores via the afterEach restore() already in place
+        stub(directEditing, 'complete').callsFake(function() {
+          callCount++;
+
+          // fire a second focusout synchronously on first call only
+          if (callCount === 1) {
+            var reentrantEvent = document.createEvent('Event');
+            reentrantEvent.initEvent('focusout', true, true);
+            reentrantEvent.relatedTarget = null;
+
+            content.dispatchEvent(reentrantEvent);
+          }
+
+          return originalComplete();
+        });
+
+        // when
+        var focusEvent = document.createEvent('Event');
+        focusEvent.initEvent('focusout', true, true);
+        focusEvent.relatedTarget = null;
+
+        content.dispatchEvent(focusEvent);
+
+        // then - complete should only have been called once (re-entrant call was blocked)
+        expect(callCount).to.eql(1);
       }));
 
     });


### PR DESCRIPTION
### Proposed Changes
This PR implements synchronous `focusout` completion natively on the `TextBox` component. It ensures that direct editing is saved immediately when focus leaves the active editor (e.g., clicking outside the canvas or switching browser windows), preventing the editor from getting stuck in an "open" state. 

By handling this inside `diagram-js-direct-editing`, we eliminate the need for global canvas capture hacks in downstream libraries like `bpmn-js` and `dmn-js`.

### What Changed
* **Native Focus Handling:** Bound a `focusout` listener directly to the `contenteditable` DOM element.
* **Teardown Guards:** Added `isConnected` checks and a `try/finally` re-entrancy guard to prevent `NotFoundError` crashes and double-completions during programmatic teardown.
* **Test Porting:** Ported the edge-case focus loss test suite from `bpmn-js` directly into the core `DirectEditingSpec.js`.

### Checklist
- [x] Brief textual description of the changes present
- [x] The code adheres to the project conventions
- [x] The code is tested (`npm run all` passes)
- [x] The commit messages adhere to the conventional commits guidelines

**Closes bpmn-io/bpmn-js#2327**
**Refs #54** (Resolves the integration issues that stalled the previous approach).


<img width="1089" height="471" alt="image" src="https://github.com/user-attachments/assets/852ce50a-e7a2-4315-bb6a-d056e4f778d8" />
