### PR TITLE
feat: allow blocking direct editing activate

### DIFF
--- a/lib/DirectEditing.js
+++ b/lib/DirectEditing.js
@@ -163,6 +163,10 @@ DirectEditing.prototype.activate = function(element) {
     this.cancel();
   }
 
+  if (this._eventBus.fire('directEditing.activate.allowed', { element: element }) === false) {
+    return false;
+  }
+
   // the direct editing context
   var context;
 

--- a/test/DirectEditingSpec.js
+++ b/test/DirectEditingSpec.js
@@ -221,6 +221,29 @@ describe('diagram-js-direct-editing', function() {
       }));
 
 
+      it('should NOT activate when not allowed', inject(function(canvas, directEditing, eventBus) {
+
+        // given
+        var shapeWithLabel = {
+          id: 's1',
+          x: 20, y: 10, width: 60, height: 50,
+          label: 'FOO'
+        };
+        canvas.addShape(shapeWithLabel);
+
+        eventBus.on('directEditing.activate.allowed', function() {
+          return false;
+        });
+
+        // when
+        var activated = directEditing.activate(shapeWithLabel);
+
+        // then
+        expect(activated).to.eql(false);
+        expect(directEditing.isActive()).to.eql(false);
+      }));
+
+
       it('should cancel', inject(function(canvas, directEditing) {
 
         // given


### PR DESCRIPTION
### Proposed Changes

Allows blocking direct editing activation (e.g. when canvas is considered locked):

```
eventBus.on('directEditing.activate.allowed', function() {
  return false;
});
```

Related to https://github.com/camunda/camunda-modeler/issues/5916

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
